### PR TITLE
Polygon union robustness

### DIFF
--- a/Tests/ASPolygonKitTests/ASPolygonKitTests.swift
+++ b/Tests/ASPolygonKitTests/ASPolygonKitTests.swift
@@ -27,7 +27,7 @@ class ASPolygonKitTests: XCTestCase {
     let polygons = try polygonsFromJSON(named: "polygons-ch-170224")
     XCTAssertEqual(5, polygons.count)
     
-    let merged = Polygon.union(polygons)
+    let merged = try Polygon.union(polygons)
     XCTAssertEqual(1, merged.count)
   }
   
@@ -35,7 +35,7 @@ class ASPolygonKitTests: XCTestCase {
     let polygons = try polygonsFromJSON(named: "polygons-uk-170217")
     XCTAssertEqual(19, polygons.count)
     
-    let merged = Polygon.union(polygons)
+    let merged = try Polygon.union(polygons)
     XCTAssertEqual(1, merged.count)
   }
 
@@ -43,18 +43,25 @@ class ASPolygonKitTests: XCTestCase {
     let polygons = try polygonsFromJSON(named: "polygons-scandinavia-170217")
     XCTAssertEqual(16, polygons.count)
     
-    let merged = Polygon.union(polygons)
+    let merged = try Polygon.union(polygons)
     XCTAssertEqual(1, merged.count)
   }
   
+  func testStaya() throws {
+    let polygons = try polygonsFromJSON(named: "polygons-au-211102")
+    XCTAssertEqual(13, polygons.count)
+    
+    let merged = try Polygon.union(polygons)
+    XCTAssertEqual(7, merged.count)
+  }
   
   func testInvariantToShuffling() throws {
     let polygons = try polygonsFromJSON(named: "polygons-uk-170217")
     XCTAssertEqual(19, polygons.count)
     
-    let _ = (1...100).map { _ in
+    let _ = try (1...100).map { _ in
       let shuffled = polygons.shuffled()
-      let merged = Polygon.union(shuffled)
+      let merged = try Polygon.union(shuffled)
       XCTAssertEqual(1, merged.count)
     }
   }
@@ -62,15 +69,16 @@ class ASPolygonKitTests: XCTestCase {
   func testOCFailure() throws {
     var grower = Polygon(pairs: [ (4,0), (4,3), (1,3), (1,0) ])
     let addition = Polygon(pairs: [ (5,1), (5,4), (3,4), (3,2), (2,2), (2,4), (0,4), (0,1) ])
-    try grower.union(addition)
+    let merged = try grower.union(addition)
+    XCTAssertTrue(merged)
     XCTAssertEqual(12, grower.points.count)
   }
-  
   
   func testSinglePointFailure() throws {
     var grower = Polygon(pairs: [ (53.5,-7.77), (52.15,-6.25), (51.2,-10) ])
     let addition = Polygon(pairs: [ (53.4600,-7.77), (54,-10), (55,-7.77) ])
-    try grower.union(addition)
+    let merged = try grower.union(addition)
+    XCTAssertTrue(merged)
     XCTAssert(grower.points.count > 1)
   }
   
@@ -85,7 +93,8 @@ class ASPolygonKitTests: XCTestCase {
     var grower = Polygon(pairs: [ (60.0000,-5.0000), (60.0000,0.0000), (56.2000,0.0000), (56.2000,-5.0000) ] )
     let addition = Polygon(pairs: [ (56.2500,-5.0000), (56.2500,0.0000), (55.9500,-1.8500), (55.1700,-5.7700) ] )
     
-    try grower.union(addition)
+    let merged = try grower.union(addition)
+    XCTAssertTrue(merged)
     XCTAssert(grower.points.count > 1)
   }
 }

--- a/Tests/ASPolygonKitTests/data/polygons-au-211102.json
+++ b/Tests/ASPolygonKitTests/data/polygons-au-211102.json
@@ -1,0 +1,18 @@
+{
+    "polygons": [
+      "~{vvEwa}kYooxC??_pvBnoxC?",
+      "~nnqC_wlnX_etB??oljB~dtB?",
+      "~cviGolgqZourQ??o_vWnurQ?",
+      "~gmcC_mmvZ_sv^??_x_X~rv^?",
+      "~pf{Eajgb[|Ef`]o{^z~[w|zHswg@tw@ygfOvuoDdPai@aocCnilMzebB_vvCfkcKyra@smTsrGblL}kGztAy~IpnBqtMngJu}K`{@oya@dwBsuWrmTu_Ll_d@||Jh`]u{Gh}LlrSt{Z",
+      "~ovmA_ho{W_g{C??_xnD~f{C?",
+      "hfcnEgrj{Y`qd@eeqBctKww\\eMkb_AlpPq~j@rn^o_d@z_k@q|H~ab@_bOaoh@iyYbMirVpeTapJlrGwvn@vcVqpo@|vc@hhCj~d@apJd~@}re@daYewB`zi@mhtAzil@wr{@xkZghNttc@yn}@w_m@mu[{oJ}oU?sxXJzK`_cIwsAlrA`biAlie@ney@txn@}nDtip@{u`Ap`_@dbt@dgyB~t~A`J~`gR",
+      "vk{gFqwfsZ{bp@pq`A{bo@tjDgpe@{iy@a`BwrrA`ds@ubiBfvfBr~iAxuJ}vQvsLogCdgD`eTrcFdwBkvAjqh@tea@fo_A{lu@ben@",
+      "~qtwE_sxvT_zwl@??_oyo@~ywl@?",
+      "b{niFmgauZjvAcph@a}EugBw`DylTsgLteCiyJl_RctfBedjAs_s@nthBvJ~pHi`cIrfAym@wkcAzzXuyiArbMykx@sbM_`~@~aW}xeAaf[{byAk`Bi{fA~a\\}j_AxgvB_og@f}WzlPrzjCmkmJj_kI~y{GyKns|Mi}~B~yaF",
+      "`e|pEggoq[?f``AaerM??mcjRnwyR??dbiP",
+      "`x|pDamoh[aosh@_{KykhBmhuOprjAecdOdkpc@pbq@j[``A~TfNbUzTjIzEsCfCeF`PiBJcWr{@}`AzbDqT`w@zElTClEvEvj@bN|LldBfpAxS~T?tWfL|SfCvQpXfdAzb@v`@d_@nj@ju@rm@xSlq@|a@pd@fo@|i@xd@nU|Pa@hpQhea@lcEtov@pFx}q@mgGb}b@hfm@nvoAjwqAhdPxtp@pxqBo|NvhpQ",
+      "puncEk_hg[}sEmn~Zy`bF_k{AywzL{byA}fkB|hRyd@v|Cj[b|@`r@`s@oyBhjHdMnhA`iFdeInoBduCjcCj}AlpB`kFsh@p~GjuL~tYvpFfjp@f]zvc@{{Dpm_@ypF~zKn}Tv~_@djZph~@v}_@sjDrfj@hkSfqEnwnCfbExbpPdunRf`]",
+    ]
+}
+


### PR DESCRIPTION
- Throw errors up the chain
- Return whether a polygon was merged or not
- If A can't be merged into B as B couldn't find a point outside, try
  the other way around.

Changes from https://github.com/skedgo/tripkit-ios/pull/111/